### PR TITLE
Use in-memory cache for certificates

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "validator": "^5.3.0"
   },
   "devDependencies": {
+    "nock": "^8.0.0",
     "tap": "^6.1.1",
     "unroll": "^1.1.0"
   }


### PR DESCRIPTION
- Don't cache certificates in /tmp/
- Fix bugs in error response handling
- Add unit tests for fetchCert()
- Fixes https://github.com/mreinstein/alexa-verifier/issues/5
