### PR TITLE
Replaced openssl-cert-tools by node-forge to validate pem certificates

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function getCert(cert_url, callback) {
       return callback(er)
     }
 
-    validateCert.validate(pem_cert, function(er) {
+    validateCert(pem_cert, function(er) {
       if (er) {
         return callback(er)
       }

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ var request = require('request')
 var url = require('url')
 var validator = require('validator')
 var validateCertUri = require('./validate-cert-uri')
-var forge = require('node-forge');
-var pki = forge.pki;
+var validateCert = require('./validate-cert');
 
 // constants
 var TIMESTAMP_TOLERANCE = 150
@@ -23,38 +22,13 @@ function getCert(cert_url, callback) {
       return callback(er)
     }
 
-    validateCert(pem_cert, function(er) {
+    validateCert.validate(pem_cert, function(er) {
       if (er) {
         return callback(er)
       }
       callback(er, pem_cert)
     })
   })
-}
-
-
-function validateCert(pem_cert, callback) {
-  try {
-    var cert = pki.certificateFromPem(pem_cert);
-    
-    // check that the domain echo-api.amazon.com is present in the Subject
-    // Alternative Names (SANs) section of the signing certificate
-    if (cert.subject.getField('CN').value.indexOf('echo-api.amazon.com') === -1) {
-      return callback('subjectAltName Check Failed')
-    }
-
-    var notAfter = new Date(cert.validity.notAfter);
-    var remainingDays = notAfter.getTime() - new Date().getTime();
-    // check that the signing certificate has not expired (examine both the Not
-    // Before and Not After dates)
-    if (remainingDays < 1) {
-      return callback('certificate expiration check failed')
-    }
-
-    callback()
-  } catch (e) {
-    return callback(e);
-  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Mike Reinstein",
   "license": "MIT",
   "dependencies": {
-    "openssl-cert-tools": "^1.2.0",
+    "node-forge": "^0.6.48",
     "request": "^2.67.0",
     "validator": "^6.2.0"
   },

--- a/test/validate-cert.js
+++ b/test/validate-cert.js
@@ -19,7 +19,7 @@ function createInvalidCert() {
   var forge = require('node-forge');
   var pki = forge.pki;
 
-  var keys = pki.rsa.generateKeyPair(2048);
+  var keys = pki.rsa.generateKeyPair(512);
   var cert = pki.createCertificate();
   cert.publicKey = keys.publicKey;
   // alternatively set public key from a csr

--- a/test/validate-cert.js
+++ b/test/validate-cert.js
@@ -98,7 +98,7 @@ function createInvalidCert() {
 }
 
 test('fails on invalid pem cert parameter', function(t) {
-  validateCert.validate(null, function(er) {
+  validateCert(null, function(er) {
     t.assert(er !== null, 'Errot should have been thrown');
     t.end();
   });
@@ -107,7 +107,7 @@ test('fails on invalid pem cert parameter', function(t) {
 test('fails on non amazon subject common name', function(t) {
   var pem = createInvalidCert();
 
-  validateCert.validate(pem, function(er) {
+  validateCert(pem, function(er) {
     t.assert(er === 'subjectAltName Check Failed', 'Certificate must be from amazon');
     t.end();
   });
@@ -115,7 +115,7 @@ test('fails on non amazon subject common name', function(t) {
 
 test('fails on expired certificate', function(t) {
   getEchoCert(oldCertUrl, function(pem) {
-    validateCert.validate(pem, function(er) {
+    validateCert(pem, function(er) {
       t.assert(er === 'certificate expiration check failed', 'Certificate is expired');
       t.end();
     });
@@ -124,7 +124,7 @@ test('fails on expired certificate', function(t) {
 
 test('approves valid certifcate', function(t) {
   getEchoCert(latestCertUrl, function(pem) {
-    validateCert.validate(pem, function(er) {
+    validateCert(pem, function(er) {
       t.assert(!er, 'Certificate should be valid');
       t.end();
     });

--- a/test/validate-cert.js
+++ b/test/validate-cert.js
@@ -1,0 +1,132 @@
+var test = require('tap').test
+var url = require('url')
+var validateCert = require('../validate-cert');
+var request = require('request');
+
+
+var oldCertUrl = 'https://s3.amazonaws.com/echo.api/echo-api-cert.pem';
+
+var latestCertUrl = 'https://s3.amazonaws.com/echo.api/echo-api-cert-4.pem';
+
+function getEchoCert(certUrl, callback) {
+  request(certUrl, function(err, res, body){
+    callback(body);
+  })
+}
+
+function createInvalidCert() {
+  // From node-forge documentation
+  var forge = require('node-forge');
+  var pki = forge.pki;
+
+  var keys = pki.rsa.generateKeyPair(2048);
+  var cert = pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  // alternatively set public key from a csr
+  //cert.publicKey = csr.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+  var attrs = [{
+    name: 'commonName',
+    value: 'example.org'
+  }, {
+    name: 'countryName',
+    value: 'US'
+  }, {
+    shortName: 'ST',
+    value: 'Virginia'
+  }, {
+    name: 'localityName',
+    value: 'Blacksburg'
+  }, {
+    name: 'organizationName',
+    value: 'Test'
+  }, {
+    shortName: 'OU',
+    value: 'Test'
+  }];
+  cert.setSubject(attrs);
+  // alternatively set subject from a csr
+  //cert.setSubject(csr.subject.attributes);
+  cert.setIssuer(attrs);
+  cert.setExtensions([{
+    name: 'basicConstraints',
+    cA: true
+  }, {
+    name: 'keyUsage',
+    keyCertSign: true,
+    digitalSignature: true,
+    nonRepudiation: true,
+    keyEncipherment: true,
+    dataEncipherment: true
+  }, {
+    name: 'extKeyUsage',
+    serverAuth: true,
+    clientAuth: true,
+    codeSigning: true,
+    emailProtection: true,
+    timeStamping: true
+  }, {
+    name: 'nsCertType',
+    client: true,
+    server: true,
+    email: true,
+    objsign: true,
+    sslCA: true,
+    emailCA: true,
+    objCA: true
+  }, {
+    name: 'subjectAltName',
+    altNames: [{
+      type: 6, // URI
+      value: 'http://example.org/webid#me'
+    }, {
+      type: 7, // IP
+      ip: '127.0.0.1'
+    }]
+  }, {
+    name: 'subjectKeyIdentifier'
+  }]);
+
+  // self-sign certificate
+  cert.sign(keys.privateKey);
+
+  var pem = pki.certificateToPem(cert);
+  return pem;
+}
+
+test('fails on invalid pem cert parameter', function(t) {
+  validateCert.validate(null, function(er) {
+    t.assert(er !== null, 'Errot should have been thrown');
+    t.end();
+  });
+})
+
+test('fails on non amazon subject common name', function(t) {
+  var pem = createInvalidCert();
+
+  validateCert.validate(pem, function(er) {
+    t.assert(er === 'subjectAltName Check Failed', 'Certificate must be from amazon');
+    t.end();
+  });
+})
+
+test('fails on expired certificate', function(t) {
+  getEchoCert(oldCertUrl, function(pem) {
+    validateCert.validate(pem, function(er) {
+      t.assert(er === 'certificate expiration check failed', 'Certificate is expired');
+      t.end();
+    });
+  });
+})
+
+test('approves valid certifcate', function(t) {
+  getEchoCert(latestCertUrl, function(pem) {
+    validateCert.validate(pem, function(er) {
+      t.assert(!er, 'Certificate should be valid');
+      t.end();
+    });
+  });
+})

--- a/validate-cert.js
+++ b/validate-cert.js
@@ -1,0 +1,30 @@
+var forge = require('node-forge');
+var pki = forge.pki;
+
+function validate(pem_cert, callback) {
+  try {
+    var cert = pki.certificateFromPem(pem_cert);
+
+    // check that the domain echo-api.amazon.com is present in the Subject
+    // Alternative Names (SANs) section of the signing certificate
+    if (cert.subject.getField('CN').value.indexOf('echo-api.amazon.com') === -1) {
+      return callback('subjectAltName Check Failed')
+    }
+
+    var notAfter = new Date(cert.validity.notAfter);
+    var remainingDays = notAfter.getTime() - new Date().getTime();
+    // check that the signing certificate has not expired (examine both the Not
+    // Before and Not After dates)
+    if (remainingDays < 1) {
+      return callback('certificate expiration check failed')
+    }
+
+    callback()
+  } catch (e) {
+    return callback(e);
+  }
+}
+
+module.exports = {
+  validate: validate
+};

--- a/validate-cert.js
+++ b/validate-cert.js
@@ -1,7 +1,7 @@
 var forge = require('node-forge');
 var pki = forge.pki;
 
-function validate(pem_cert, callback) {
+module.exports = function validate(pem_cert, callback) {
   try {
     var cert = pki.certificateFromPem(pem_cert);
 
@@ -24,7 +24,3 @@ function validate(pem_cert, callback) {
     return callback(e);
   }
 }
-
-module.exports = {
-  validate: validate
-};


### PR DESCRIPTION
Fixes https://github.com/alexa-js/alexa-verifier/issues/11 by not using native openssl which seems to  introduce bugs in openssl-cert-tools as of 1.0.2k